### PR TITLE
[PROD-1440] - Handling fragment DeprecationWarning

### DIFF
--- a/submit_and_compare/mixins/fragment.py
+++ b/submit_and_compare/mixins/fragment.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 from django.template.context import Context
 from xblock.core import XBlock
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 
 
 class XBlockFragmentBuilderMixin(object):


### PR DESCRIPTION
### [PROD-1440](https://openedx.atlassian.net/browse/PROD-1440)

Reducing logs to free up space in Splunk for a more meaningful history. Handling DeprecationWarning got `fragment`

`DeprecationWarning: xblock.fragment is deprecated. Please use web_fragments.fragment instead`